### PR TITLE
Set local storage item when state is initialised

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ export default Example;
 bun install
 ```
 
-#### To build:
+#### Build in watch mode:
 
 Note: The build uses `tsc` instead of `bun` as `Bun` currenlty has a bug where React is bundled in the build which causes the `Invalid hook call` error. Once this has been fixed, `bun` will be used.
 
 ```bash
-bun run build
+bun dev
 ```
 
 #### Run example:

--- a/examples/src/components/ComponentOne.tsx
+++ b/examples/src/components/ComponentOne.tsx
@@ -1,6 +1,4 @@
-import useLocalStorage, {
-  LocalStorageValue
-} from "react-persist-local-storage";
+import useLocalStorage, { LocalStorageValue } from "../../../build/index";
 import "./ComponentOne.css";
 
 /**
@@ -14,6 +12,7 @@ const ComponentOne = () => {
   });
 
   const parseValueAsString = (val: LocalStorageValue<typeof value>) => {
+    if (val === null) return "";
     if (typeof val === "object") return JSON.stringify(val);
     else return String(val);
   };

--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -1,7 +1,7 @@
 /// <reference lib="dom" />
 /// <reference lib="dom.iterable" />
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { isValidJson } from "./util";
 
 export type LocalStorageValue<T> = T extends null
@@ -54,6 +54,7 @@ const useLocalStorage = <T>(
       const parsedInitialValue = parseValue(initialValue);
       try {
         const item = localStorage.getItem(key);
+        if (!item) localStorage.setItem(key, parsedInitialValue);
         const isJson = isValidJson(item || "");
         return isJson ? JSON.parse(item || "") : item;
       } catch (error) {
@@ -62,10 +63,6 @@ const useLocalStorage = <T>(
       }
     }
   );
-
-  useEffect(() => {
-    localStorage.setItem(key, parseValue(initialValue));
-  }, []);
 
   /**
    * Sets the state value to 'value'.


### PR DESCRIPTION
Set local storage item when the state is initialised. This helps keep these in sync when local storage is deleted

- Improve 'Development' section of README.
- Fixes bug in examples component where the input value was set to `null` when local storage item was deleted with the `deleteItem` function.