### PR TITLE
Storage syncing between windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,25 @@ Supports object and string types.
 ## Features
 
 - Keeps React state in sync with local storage.
+- Keeps local storage in sync between windows.
 - Add, update and delete local storage items.
 - Static typing when using objects!
+
+## Reference
+
+### `useLocalStorage(key, initialValue, options)`
+
+#### Parameters
+
+- `key`: The local storage key.
+- `initialValue`: Initial value of the localstorage value.
+- `options.sync`: Enable local storage syncing between windows.
+
+#### Returns
+
+1. The serialized local storage value.
+2. Function for setting the local storage value.
+3. Function for removing the local storage item.
 
 ## Example Usage:
 

--- a/examples/src/components/component_one/ComponentOne.tsx
+++ b/examples/src/components/component_one/ComponentOne.tsx
@@ -9,7 +9,8 @@ const ComponentOne = () => {
   const key = "component.one.example";
   const [value, setValue, deleteValue] = useLocalStorage(
     key,
-    "Test Value"
+    "Test Value",
+    { sync: true }
   );
 
   return (

--- a/examples/src/components/component_two/ComponentTwo.tsx
+++ b/examples/src/components/component_two/ComponentTwo.tsx
@@ -9,9 +9,13 @@ import "./ComponentTwo.css";
  */
 const ComponentTwo = () => {
   const key = "component.two.example";
-  const [value, setValue, deleteValue] = useLocalStorage(key, {
-    value: "test value"
-  });
+  const [value, setValue, deleteValue] = useLocalStorage(
+    key,
+    {
+      value: "test value"
+    },
+    { sync: true }
+  );
 
   const parseValueAsString = (val: LocalStorageValue<typeof value>) => {
     return JSON.stringify(val);

--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -109,6 +109,7 @@ const useLocalStorage = <T>(
       } else {
         newValue = event.newValue as LocalStorageValue<T>;
       }
+      //console.log(newValue, event.key);
       setValue(newValue, event.key as string);
     };
     window.addEventListener("storage", onStorageChange);

--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -109,7 +109,6 @@ const useLocalStorage = <T>(
       } else {
         newValue = event.newValue as LocalStorageValue<T>;
       }
-      //console.log(newValue, event.key);
       setValue(newValue, event.key as string);
     };
     window.addEventListener("storage", onStorageChange);

--- a/tests/useLocalStorage.test.ts
+++ b/tests/useLocalStorage.test.ts
@@ -83,4 +83,66 @@ describe("useLocalStorage tests", () => {
 
     expect(localStorage.getItem(testKey)).toBeNull();
   });
+
+  test("Storage event syncs string values between hooks when sync enabled", () => {
+    const testKey = "test1.key";
+    const test1Value = "test1 value";
+    const { result: result1 } = renderHook(() =>
+      useLocalStorage(testKey, test1Value, { sync: true })
+    );
+    const test2Value = "test2 value";
+    const { result: result2 } = renderHook(() =>
+      useLocalStorage(testKey, test2Value, { sync: true })
+    );
+
+    const newTestValue = "new test value";
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: testKey,
+          newValue: newTestValue
+        })
+      );
+    });
+
+    expect(localStorage.getItem(testKey)).toBe(newTestValue);
+    expect(result1.current[0]).toBe(newTestValue);
+
+    expect(localStorage.getItem(testKey)).toBe(newTestValue);
+    expect(result2.current[0]).toBe(newTestValue);
+  });
+
+  test("Storage event syncs JSON values between hooks when sync enabled", () => {
+    const testKey = "test1.key";
+    const test1Value = { value: "test1 value" };
+    const { result: result1 } = renderHook(() =>
+      useLocalStorage(testKey, test1Value, { sync: true })
+    );
+    const test2Value = { value: "test2 value" };
+    const { result: result2 } = renderHook(() =>
+      useLocalStorage(testKey, test2Value, { sync: true })
+    );
+
+    const newTestValue = { value: "new test value" };
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: testKey,
+          newValue: JSON.stringify(newTestValue)
+        })
+      );
+    });
+
+    expect(localStorage.getItem(testKey)).toBe(
+      JSON.stringify(newTestValue)
+    );
+    expect(result1.current[0]).toEqual(newTestValue);
+
+    expect(localStorage.getItem(testKey)).toBe(
+      JSON.stringify(newTestValue)
+    );
+    expect(result2.current[0]).toEqual(newTestValue);
+  });
 });


### PR DESCRIPTION
New Feature for keeping local storage values in sync between windows using a `storage` event listener.

### Changes:
- Effect for listening for storage events.
- Unit tests.
- New `Reference` section in `README`.