### PR TITLE
Missing doc param

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-persist-local-storage": "^0.6.1"
+        "react-persist-local-storage": "^0.6.2"
       },
       "devDependencies": {
         "@types/react": "^19.1.5",
@@ -2808,9 +2808,9 @@
       }
     },
     "node_modules/react-persist-local-storage": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/react-persist-local-storage/-/react-persist-local-storage-0.6.1.tgz",
-      "integrity": "sha512-++Du3SNP6RvvU/KVTFt/YXlNZ0u9l4aWUbustE4E3hMXDzCxJO8Nyll7uIikvswaZbGYWfrywbjS14kPEaxb/g==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/react-persist-local-storage/-/react-persist-local-storage-0.6.2.tgz",
+      "integrity": "sha512-xjMf/gVquJdkTdojtX/usFI202DY3ZybQCEZMQkakuw7/PnF1eiu82rubwCto8llDntBJGXsSQc848++O4V+cw==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=18.0.0 <20.0.0"

--- a/examples/package.json
+++ b/examples/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-persist-local-storage": "^0.6.1"
+    "react-persist-local-storage": "^0.6.2"
   },
   "devDependencies": {
     "@types/react": "^19.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-persist-local-storage",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-persist-local-storage",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-persist-local-storage",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -72,6 +72,7 @@ const useLocalStorage = <T>(
    * Sets the state value to 'value'.
    *
    * @param value The new local storage value.
+   * @param eventKey The key of the event that triggered the change.
    */
   const setValue = (value: LocalStorageValue<T>, eventKey?: string) => {
     try {


### PR DESCRIPTION
Changes:
- Added missing doc param in `useLocalStorage` hook for `setValue` function.
- New patch version - `0.6.2`.